### PR TITLE
Add FastAPI scaffold for Moroccan ID extraction API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,80 @@
-building a python api that will take an image file of an id moroccan and return a json of the extracted data as simple as that
+# Moroccan ID Extraction API
+
+This project exposes a small FastAPI service capable of receiving an image of a Moroccan
+national ID card and returning the parsed information as JSON. The current
+implementation ships with a mocked extraction routine so that the API contract can be
+tested end-to-end before the OCR pipeline is integrated.
+
+## Project structure
+
+```
+.
+├── readme.md
+└── src
+    └── api
+        ├── __init__.py
+        ├── main.py
+        └── schemas.py
+```
+
+* `src/api/main.py` hosts the FastAPI application and HTTP routes.
+* `src/api/schemas.py` contains the Pydantic models that drive request validation and
+  the response schema.
+
+## Getting started
+
+1. Create a virtual environment and install the runtime dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install fastapi uvicorn
+   ```
+
+2. Start the development server with auto-reload enabled:
+
+   ```bash
+   uvicorn src.api.main:app --reload
+   ```
+
+   The API will be available at <http://127.0.0.1:8000>. An OpenAPI specification and
+   interactive Swagger UI are exposed at <http://127.0.0.1:8000/docs>.
+
+## Usage
+
+### Health check
+
+Verify that the service is running:
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+### Extract ID fields
+
+Submit a Moroccan ID card image via multipart upload. An optional `include_address`
+query parameter controls whether the parsed address should be included in the
+response.
+
+```bash
+curl \
+  -X POST "http://127.0.0.1:8000/extract?include_address=true" \
+  -F "image=@/path/to/id-card.jpg"
+```
+
+A successful request returns the structured fields in JSON:
+
+```json
+{
+  "fields": {
+    "cin": "AA123456",
+    "full_name": "Example Citizen",
+    "date_of_birth": "1990-01-01",
+    "address": "123 Rue de l'Example, Casablanca"
+  },
+  "message": "Extraction completed successfully."
+}
+```
+
+Replace the sample OCR logic inside `src/api/main.py` with your preferred document
+processing pipeline to produce real extraction results.

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,5 @@
+"""Application package for the ID card extraction API."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,106 @@
+"""FastAPI application exposing an ID card data extraction endpoint."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Iterable
+
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
+)
+
+from .schemas import ExtractionRequest, ExtractionResponse, IDCardFields
+
+app = FastAPI(
+    title="Moroccan ID Extraction API",
+    version="0.1.0",
+    description=(
+        "Upload an image of a Moroccan national ID card to receive structured "
+        "data such as CIN, name, date of birth and address."
+    ),
+)
+
+SUPPORTED_IMAGE_TYPES: Iterable[str] = {
+    "image/jpeg",
+    "image/png",
+    "image/jpg",
+    "image/webp",
+}
+
+
+def _build_request(
+    include_address: bool = Query(
+        True,
+        description="Return the postal address detected on the ID card when true.",
+    ),
+) -> ExtractionRequest:
+    """Dependency that constructs an :class:`ExtractionRequest` from query params."""
+
+    return ExtractionRequest(include_address=include_address)
+
+
+async def _simulate_extraction(
+    upload: UploadFile,
+    request_data: ExtractionRequest,
+) -> IDCardFields:
+    """Simulate the extraction routine and return structured fields.
+
+    In a production system this function would call into an OCR/NER pipeline.
+    For now it simply validates that the uploaded file contains bytes and
+    returns placeholder data in the expected format.
+    """
+
+    contents = await upload.read()
+    if not contents:
+        raise ValueError("The uploaded file appears to be empty.")
+
+    extracted = IDCardFields(
+        cin="AA123456",
+        full_name="Example Citizen",
+        date_of_birth=date(1990, 1, 1),
+        address="123 Rue de l'Example, Casablanca",
+    )
+
+    if not request_data.include_address:
+        extracted = extracted.copy(update={"address": None})
+
+    return extracted
+
+
+@app.post("/extract", response_model=ExtractionResponse, status_code=status.HTTP_200_OK)
+async def extract_id_card(
+    image: UploadFile = File(..., description="Image of the Moroccan ID card to parse."),
+    request_data: ExtractionRequest = Depends(_build_request),
+) -> ExtractionResponse:
+    """Process the uploaded ID card image and return structured information."""
+
+    if image.content_type not in SUPPORTED_IMAGE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported file type. Upload a JPEG, PNG or WEBP image.",
+        )
+
+    try:
+        fields = await _simulate_extraction(image, request_data)
+    except ValueError as exc:  # pragma: no cover - placeholder error path
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    finally:
+        await image.close()
+
+    return ExtractionResponse(fields=fields)
+
+
+@app.get("/health", status_code=status.HTTP_200_OK)
+async def health_check() -> dict[str, str]:
+    """Simple endpoint to verify that the API is running."""
+
+    return {"status": "ok"}

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,0 +1,41 @@
+"""Pydantic models used by the ID extraction API."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class IDCardFields(BaseModel):
+    """Structured data extracted from a Moroccan ID card."""
+
+    cin: str = Field(..., description="Unique national identification number (CIN).")
+    full_name: str = Field(..., description="Citizen's full name exactly as printed on the document.")
+    date_of_birth: date = Field(..., description="Date of birth found on the ID card.")
+    address: Optional[str] = Field(
+        None, description="Primary address listed on the identification document."
+    )
+
+
+class ExtractionRequest(BaseModel):
+    """User-configurable options that influence the extraction pipeline."""
+
+    include_address: bool = Field(
+        True,
+        description=(
+            "When set to true the API will attempt to extract the registered address "
+            "from the ID image."
+        ),
+    )
+
+
+class ExtractionResponse(BaseModel):
+    """Response envelope returned by the extraction endpoint."""
+
+    fields: IDCardFields = Field(..., description="Parsed information detected on the ID card.")
+    message: str = Field(
+        "Extraction completed successfully.",
+        description="Human-readable summary of the extraction result.",
+    )


### PR DESCRIPTION
## Summary
- set up a FastAPI application under `src/api/main.py` with health and `/extract` routes
- add Pydantic schemas to describe extraction options and responses
- document project structure, dependencies, and usage instructions in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ced48a6fa48323a5963ed35fe2e996