### PR TITLE
Remove binary fixture from tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,41 +1,68 @@
 # Moroccan ID Extraction API
 
 This project exposes a small FastAPI service capable of receiving an image of a Moroccan
-national ID card and returning the parsed information as JSON. The current
-implementation ships with a mocked extraction routine so that the API contract can be
-tested end-to-end before the OCR pipeline is integrated.
+national ID card and returning the parsed information as JSON. The application now
+ships with an OCR-based extraction pipeline powered by Tesseract, OpenCV and Pillow to
+detect the CIN, holder name, date of birth and optional postal address.
 
 ## Project structure
 
 ```
 .
 ├── readme.md
-└── src
-    └── api
-        ├── __init__.py
-        ├── main.py
-        └── schemas.py
+├── requirements.txt
+├── src
+│   └── api
+│       ├── __init__.py
+│       ├── main.py
+│       ├── ocr.py
+│       └── schemas.py
+└── tests
+    ├── conftest.py
+    └── test_ocr.py
 ```
 
 * `src/api/main.py` hosts the FastAPI application and HTTP routes.
+* `src/api/ocr.py` contains the OCR pipeline and heuristics used to parse Moroccan ID
+  cards.
 * `src/api/schemas.py` contains the Pydantic models that drive request validation and
   the response schema.
+* `tests/` bundles unit coverage for the OCR module. The tests synthesise an
+  in-memory placeholder image so no binary fixtures are tracked in the
+  repository.
 
 ## Getting started
 
-1. Create a virtual environment and install the runtime dependencies:
+1. Install the native [Tesseract OCR](https://tesseract-ocr.github.io/tessdoc/) binary.
+   On Debian/Ubuntu based systems this can be achieved with:
 
    ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   pip install fastapi uvicorn
+   sudo apt-get update
+   sudo apt-get install tesseract-ocr libtesseract-dev
    ```
 
-2. Start the development server with auto-reload enabled:
+   Refer to the Tesseract documentation for installation steps on Windows or macOS.
+
+2. Create a virtual environment and install the Python dependencies listed in
+   `requirements.txt`:
+
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+    ```
+
+3. (Optional) Install additional tooling used for tests and linting:
 
    ```bash
-   uvicorn src.api.main:app --reload
+   pip install pytest
    ```
+
+4. Start the development server with auto-reload enabled:
+
+    ```bash
+    uvicorn src.api.main:app --reload
+    ```
 
    The API will be available at <http://127.0.0.1:8000>. An OpenAPI specification and
    interactive Swagger UI are exposed at <http://127.0.0.1:8000/docs>.
@@ -54,7 +81,9 @@ curl http://127.0.0.1:8000/health
 
 Submit a Moroccan ID card image via multipart upload. An optional `include_address`
 query parameter controls whether the parsed address should be included in the
-response.
+response. When the underlying OCR pipeline cannot confidently detect one of the
+expected fields the endpoint responds with an HTTP 422 status code describing the
+missing data.
 
 ```bash
 curl \
@@ -67,14 +96,29 @@ A successful request returns the structured fields in JSON:
 ```json
 {
   "fields": {
-    "cin": "AA123456",
-    "full_name": "Example Citizen",
-    "date_of_birth": "1990-01-01",
-    "address": "123 Rue de l'Example, Casablanca"
+    "cin": "AB123456",
+    "full_name": "REDACTED PERSON",
+    "date_of_birth": "1985-02-01",
+    "address": "99 RUE EXEMPLE RABAT"
   },
   "message": "Extraction completed successfully."
 }
 ```
 
-Replace the sample OCR logic inside `src/api/main.py` with your preferred document
-processing pipeline to produce real extraction results.
+### OCR testing with sample images
+
+The unit tests synthesise a neutral PNG image at runtime and mock the Tesseract
+bindings. This keeps the repository free from binary fixtures while still
+exercising the OCR parsing logic. If you would like to experiment with your own
+samples, update the tests to point at a local image or call the FastAPI endpoint
+directly with a multipart upload.
+
+Run the automated checks locally with:
+
+```bash
+pytest
+```
+
+The tests mock the Tesseract bindings so they do not require the native binary to be
+installed, but the application will need a working Tesseract executable at runtime to
+process real uploads.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+pytesseract
+Pillow
+opencv-python
+numpy
+python-multipart

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,5 +1,19 @@
 """Application package for the ID card extraction API."""
 
-from .main import app
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .main import app as fastapi_app
+
+
+def __getattr__(name: str):
+    if name == "app":
+        from .main import app as fastapi_app  # local import to avoid importing FastAPI eagerly
+
+        return fastapi_app
+    raise AttributeError(f"module 'api' has no attribute {name!r}")
+
 
 __all__ = ["app"]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import date
 from typing import Iterable
 
 from fastapi import (
@@ -15,6 +14,7 @@ from fastapi import (
     status,
 )
 
+from .ocr import OCRProcessingError, extract_id_fields
 from .schemas import ExtractionRequest, ExtractionResponse, IDCardFields
 
 app = FastAPI(
@@ -45,32 +45,19 @@ def _build_request(
     return ExtractionRequest(include_address=include_address)
 
 
-async def _simulate_extraction(
+async def _run_extraction(
     upload: UploadFile,
     request_data: ExtractionRequest,
 ) -> IDCardFields:
-    """Simulate the extraction routine and return structured fields.
-
-    In a production system this function would call into an OCR/NER pipeline.
-    For now it simply validates that the uploaded file contains bytes and
-    returns placeholder data in the expected format.
-    """
+    """Execute the OCR pipeline and normalise the output based on user options."""
 
     contents = await upload.read()
-    if not contents:
-        raise ValueError("The uploaded file appears to be empty.")
+    fields = extract_id_fields(contents, include_address=request_data.include_address)
 
-    extracted = IDCardFields(
-        cin="AA123456",
-        full_name="Example Citizen",
-        date_of_birth=date(1990, 1, 1),
-        address="123 Rue de l'Example, Casablanca",
-    )
+    if not request_data.include_address and fields.address is not None:
+        fields = fields.copy(update={"address": None})
 
-    if not request_data.include_address:
-        extracted = extracted.copy(update={"address": None})
-
-    return extracted
+    return fields
 
 
 @app.post("/extract", response_model=ExtractionResponse, status_code=status.HTTP_200_OK)
@@ -87,11 +74,16 @@ async def extract_id_card(
         )
 
     try:
-        fields = await _simulate_extraction(image, request_data)
-    except ValueError as exc:  # pragma: no cover - placeholder error path
+        fields = await _run_extraction(image, request_data)
+    except OCRProcessingError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
+        ) from exc
+    except ValueError as exc:  # pragma: no cover - unexpected parsing error
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Failed to parse the uploaded ID card image.",
         ) from exc
     finally:
         await image.close()

--- a/src/api/ocr.py
+++ b/src/api/ocr.py
@@ -1,0 +1,264 @@
+"""OCR and parsing utilities for Moroccan ID cards."""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Iterable, Optional
+
+import cv2  # type: ignore
+import numpy as np
+from PIL import Image, UnidentifiedImageError
+import pytesseract
+from pytesseract import Output, TesseractError, TesseractNotFoundError
+
+from .schemas import IDCardFields
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OCRProcessingError(RuntimeError):
+    """Raised when OCR processing fails to produce structured data."""
+
+
+@dataclass(frozen=True)
+class OCRResult:
+    """Container for the intermediate OCR outputs."""
+
+    text: str
+    data: dict[str, list]
+
+
+def extract_id_fields(image_bytes: bytes, include_address: bool) -> IDCardFields:
+    """Run OCR on the provided Moroccan ID card image and parse structured fields.
+
+    Parameters
+    ----------
+    image_bytes:
+        Raw bytes representing the uploaded ID card image.
+    include_address:
+        When ``True`` the parser will attempt to extract the postal address. When
+        ``False`` the address is omitted from the returned data.
+
+    Returns
+    -------
+    IDCardFields
+        Parsed CIN, full name, date of birth and optionally the address.
+
+    Raises
+    ------
+    OCRProcessingError
+        Raised when the OCR engine fails or the expected fields cannot be
+        detected in the resulting text.
+    """
+
+    image = _load_image(image_bytes)
+    processed = _preprocess_for_ocr(image)
+    ocr_result = _perform_ocr(processed)
+
+    lines = _extract_lines(ocr_result.text)
+    cin = _parse_cin(ocr_result.data, ocr_result.text)
+    full_name = _parse_full_name(lines, ocr_result.data)
+    date_of_birth = _parse_date_of_birth(lines)
+    address = _parse_address(lines, ocr_result.data) if include_address else None
+
+    missing = [
+        field
+        for field, value in {
+            "cin": cin,
+            "full_name": full_name,
+            "date_of_birth": date_of_birth,
+        }.items()
+        if value in (None, "")
+    ]
+    if missing:
+        raise OCRProcessingError(
+            "Unable to detect the following field(s) on the ID card: "
+            + ", ".join(missing)
+        )
+
+    return IDCardFields(
+        cin=cin,
+        full_name=full_name,
+        date_of_birth=date_of_birth,
+        address=address,
+    )
+
+
+def _load_image(image_bytes: bytes) -> Image.Image:
+    if not image_bytes:
+        raise OCRProcessingError("The uploaded image appears to be empty.")
+
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            return img.convert("RGB")
+    except UnidentifiedImageError as exc:  # pragma: no cover - safety net
+        raise OCRProcessingError("Unsupported or corrupted image file provided.") from exc
+
+
+def _preprocess_for_ocr(image: Image.Image) -> np.ndarray:
+    """Apply grayscale conversion, denoising and adaptive thresholding."""
+
+    np_image = np.array(image)
+    gray = cv2.cvtColor(np_image, cv2.COLOR_RGB2GRAY)
+    denoised = cv2.bilateralFilter(gray, 9, 75, 75)
+    normalized = cv2.normalize(denoised, None, 0, 255, cv2.NORM_MINMAX)
+    thresholded = cv2.adaptiveThreshold(
+        normalized,
+        255,
+        cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+        cv2.THRESH_BINARY,
+        31,
+        8,
+    )
+    return thresholded
+
+
+def _perform_ocr(image: np.ndarray) -> OCRResult:
+    try:
+        text = pytesseract.image_to_string(
+            image,
+            lang="eng+fra",
+            config="--oem 3 --psm 6",
+        )
+        data = pytesseract.image_to_data(
+            image,
+            lang="eng+fra",
+            config="--oem 3 --psm 6",
+            output_type=Output.DICT,
+        )
+    except (TesseractNotFoundError, TesseractError) as exc:  # pragma: no cover
+        LOGGER.exception("Tesseract OCR execution failed")
+        raise OCRProcessingError("OCR engine is not available on the server.") from exc
+
+    return OCRResult(text=text, data=data)
+
+
+def _extract_lines(text: str) -> list[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _parse_cin(data: dict[str, list], raw_text: str) -> Optional[str]:
+    token_candidates = _iter_tokens(data)
+    for raw_token, normalized in token_candidates:
+        normalized_token = normalized.replace(" ", "")
+        match = re.fullmatch(r"[A-Z]{1,2}\d{5,6}", normalized_token)
+        if match:
+            return normalized_token
+
+    normalized_text = _normalise_text(raw_text)
+    match = re.search(r"\b([A-Z]{1,2}\d{5,6})\b", normalized_text)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def _parse_full_name(lines: list[str], data: dict[str, list]) -> Optional[str]:
+    label_pattern = re.compile(
+        r"^\s*(?:nom(?:\s+et\s+pr[eé]nom[s]?)?|pr[eé]nom[s]?)[:\s\-]*(?P<value>.+)$",
+        re.IGNORECASE,
+    )
+    for line in lines:
+        match = label_pattern.match(line)
+        if match:
+            return _clean_value(match.group("value"))
+
+    # Fallback to aggregated tokens - longest alphabetical span
+    tokens = [orig for orig, norm in _iter_tokens(data) if orig and orig.isalpha()]
+    if tokens:
+        candidate = " ".join(tokens)
+        if candidate:
+            return _clean_value(candidate)
+
+    return None
+
+
+def _parse_date_of_birth(lines: list[str]) -> Optional[date]:
+    date_patterns = [
+        re.compile(
+            r"(?:naissance|date\s+de\s+naissance|n[eé]e?\s+le)[:\s\-]*(\d{2}[\-/\.]\d{2}[\-/\.]\d{4})",
+            re.IGNORECASE,
+        ),
+        re.compile(r"\b(\d{2}[\-/\.]\d{2}[\-/\.]\d{4})\b"),
+    ]
+    for line in lines:
+        for pattern in date_patterns:
+            match = pattern.search(line)
+            if match:
+                raw = match.group(1)
+                parsed = _parse_date(raw)
+                if parsed:
+                    return parsed
+    return None
+
+
+def _parse_address(lines: list[str], data: dict[str, list]) -> Optional[str]:
+    address_pattern = re.compile(
+        r"^\s*(?:adresse|adress|adr)[\s:.-]*(?P<value>.+)$",
+        re.IGNORECASE,
+    )
+    for idx, line in enumerate(lines):
+        match = address_pattern.match(line)
+        if match:
+            value = _clean_value(match.group("value"))
+            if not value and idx + 1 < len(lines):
+                value = _clean_value(line + " " + lines[idx + 1])
+            if value:
+                return value
+
+    # Fallback to join tokens following address keyword
+    tokens = list(_iter_tokens(data))
+    for index, (original, normalized) in enumerate(tokens):
+        if normalized.startswith("ADRESSE"):
+            trailing = [tok for tok, _ in tokens[index + 1 : index + 6]]
+            candidate = _clean_value(" ".join(trailing))
+            if candidate:
+                return candidate
+    return None
+
+
+def _parse_date(raw: str) -> Optional[date]:
+    cleaned = raw.replace(".", "/").replace("-", "/")
+    for fmt in ("%d/%m/%Y", "%m/%d/%Y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(cleaned, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _iter_tokens(data: dict[str, list]) -> Iterable[tuple[str, str]]:
+    texts = data.get("text", []) or []
+    confs = data.get("conf", []) or []
+    for raw, conf in zip(texts, confs):
+        if not raw:
+            continue
+        try:
+            confidence = float(conf)
+        except (TypeError, ValueError):  # pragma: no cover
+            confidence = -1.0
+        if confidence < 0:  # ignore uncertain detections
+            continue
+        normalized = _normalise_text(raw)
+        if not normalized:
+            continue
+        yield _clean_value(raw), normalized
+
+
+def _normalise_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFD", value)
+    normalized = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    normalized = re.sub(r"[^A-Z0-9\s:/-]", "", normalized.upper())
+    return _clean_value(normalized)
+
+
+def _clean_value(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+__all__ = ["extract_id_fields", "OCRProcessingError"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for the Moroccan ID extraction project."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,91 @@
+"""Tests for the OCR parsing pipeline."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from api.ocr import OCRProcessingError, extract_id_fields
+
+OCR_TEXT = """
+ROYAUME DU MAROC
+CIN AB123456
+NOM ET PRENOM REDACTED PERSON
+NAISSANCE 01/02/1985
+ADRESSE 99 RUE EXEMPLE RABAT
+""".strip()
+
+OCR_DATA = {
+    "text": [
+        "ROYAUME",
+        "DU",
+        "MAROC",
+        "CIN",
+        "AB123456",
+        "NOM",
+        "ET",
+        "PRENOM",
+        "REDACTED",
+        "PERSON",
+        "NAISSANCE",
+        "01/02/1985",
+        "ADRESSE",
+        "99",
+        "RUE",
+        "EXEMPLE",
+        "RABAT",
+    ],
+    "conf": ["95"] * 17,
+}
+
+
+@pytest.fixture()
+def sample_image_bytes() -> bytes:
+    """Return an in-memory PNG image suitable for OCR preprocessing."""
+
+    image = Image.new("RGB", (256, 256), color=(240, 240, 240))
+    with BytesIO() as buffer:
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+@patch("api.ocr.pytesseract.image_to_string", return_value=OCR_TEXT)
+@patch("api.ocr.pytesseract.image_to_data", return_value=OCR_DATA)
+def test_extract_id_fields_returns_expected_data(
+    mock_data,
+    mock_text,
+    sample_image_bytes: bytes,
+) -> None:
+    result = extract_id_fields(sample_image_bytes, include_address=True)
+
+    assert result.cin == "AB123456"
+    assert result.full_name == "REDACTED PERSON"
+    assert result.date_of_birth.isoformat() == "1985-02-01"
+    assert result.address == "99 RUE EXEMPLE RABAT"
+
+
+@patch("api.ocr.pytesseract.image_to_string", return_value=OCR_TEXT)
+@patch("api.ocr.pytesseract.image_to_data", return_value=OCR_DATA)
+def test_extract_id_fields_can_skip_address(
+    mock_data,
+    mock_text,
+    sample_image_bytes: bytes,
+) -> None:
+    result = extract_id_fields(sample_image_bytes, include_address=False)
+
+    assert result.cin == "AB123456"
+    assert result.address is None
+
+
+@patch("api.ocr.pytesseract.image_to_string", return_value="INCOMPLETE DATA")
+@patch("api.ocr.pytesseract.image_to_data", return_value={"text": ["HELLO"], "conf": ["90"]})
+def test_extract_id_fields_raises_when_fields_missing(
+    mock_data,
+    mock_text,
+    sample_image_bytes: bytes,
+) -> None:
+    with pytest.raises(OCRProcessingError):
+        extract_id_fields(sample_image_bytes, include_address=True)


### PR DESCRIPTION
## Summary
- drop the committed PNG fixture from the repository
- generate a neutral in-memory image in the OCR tests instead
- update the README to reflect that tests no longer rely on binary assets

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68ced83280bc83238b97e6cb9d356196